### PR TITLE
reassign generated files to dot log and ignore log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Log files          #
+######################
+*.log
+
+# Data files         #
+######################
+*.json
+
+# OS generated files #
+######################
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db

--- a/build_tag_data_per_instance.rb
+++ b/build_tag_data_per_instance.rb
@@ -60,8 +60,8 @@ instance_tags_hash = JSON.parse(instance_tags)
 device_data = File.read('servers-20181112-162813.json') # file from Encore team
 device_data_hash = JSON.parse(device_data)
 
-output_file = File.open('tag_data_per_instance.txt','w')
-log_file = File.open('instances_not_found.txt','w')
+output_file = File.open('tag_data_per_instance.log','w')
+log_file = File.open('instances_not_found.log','w')
 
 format_instance_data(instance_tags_hash, device_data_hash, output_file, log_file)
 

--- a/cass_tags_to_json.rb
+++ b/cass_tags_to_json.rb
@@ -33,7 +33,7 @@ end
 
 input = File.open('cass_tag_dump.json','r')
 output = File.open('instance_id_to_tags.json','w')
-error_output = File.open('instance_id_to_tags_error.txt','w')
+error_output = File.open('instance_id_to_tags_error.log','w')
 
 format_tags_from_cass_dump(input, output, error_output)
 

--- a/parse_unique_ddis_from_cass_dump.rb
+++ b/parse_unique_ddis_from_cass_dump.rb
@@ -18,7 +18,7 @@ def get_unique_ddis(tags_file, output)
 end
 
 input = File.open('cass_tag_dump.json','r')
-output = File.open('unique_ddis_from_cass_tag_dump.txt','w')
+output = File.open('unique_ddis_from_cass_tag_dump.log','w')
 
 get_unique_ddis(input, output)
 


### PR DESCRIPTION
Reassign generated files to .log files and add gitignore file to ignore log files, json files for storing data to be processed, and os generated files.